### PR TITLE
Make code RW should be based only on CONFIG_DEBUG_SET_MODULE_RONX pre…

### DIFF
--- a/sources/core/kedr_instrumentor.c
+++ b/sources/core/kedr_instrumentor.c
@@ -424,8 +424,7 @@ do_process_area(void* kbeg, void* kend,
  * To be able to instrument the module anyway, we use the approach Ftrace
  * relies upon: temporarily make the code RW and make in RO again after the
  * instrumentation. */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)) && \
-    defined(CONFIG_DEBUG_SET_MODULE_RONX)
+#if defined(CONFIG_DEBUG_SET_MODULE_RONX)
 
 static int (*do_set_memory_ro)(unsigned long addr, int numpages) = NULL;
 static int (*do_set_memory_rw)(unsigned long addr, int numpages) = NULL;


### PR DESCRIPTION
…sence

Despite commit 4982223e51e8ea9d09bb33c8323b5ec1877b2b51 is present since
3.16 kernel in the upstream, it may be ported for older kernels as well
(e.g. CentOS' 3.10.0-327). So decision to make code RW or not should be
based only on CONFIG_DEBUG_SET_MODULE_RONX presence, regardless of kernel
version.