### PR TITLE
Correct number of devices to destroy

### DIFF
--- a/sources/examples/sample_target/cfake.c
+++ b/sources/examples/sample_target/cfake.c
@@ -331,7 +331,7 @@ cfake_init_module(void)
 	for (i = 0; i < cfake_ndevices; ++i) {
 		err = cfake_construct_device(&cfake_devices[i], i, cfake_class);
 		if (err) {
-			devices_to_destroy = i;
+			devices_to_destroy = i + 1;
 			goto fail;
 		}
 	}


### PR DESCRIPTION
The device creation loop increments variable 'i' _after_ the device was created.
In case of failure the devices_to_destroy value should be the current index plus one.